### PR TITLE
CI: add flake8 jobs, and faster builds using wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,17 @@ python:
 # use a pip cache
 cache:
   directories:
-  - $HOME/.pip-cache
+  - $PWD/wheelhouse
+# Tell pypi where to find wheels
+env:
+  global:
+    - export PIP_FIND_LINKS=$PWD/wheelhouse
 # command to install dependencies
 install:
-  - pip install -r requirements.txt --download-cache $HOME/.pip-cache
-  - pip install flake8 --download-cache $HOME/.pip-cache
+  - pip wheel -r requirements.txt
+  - pip wheel flake8
+  - pip install -r requirements.txt
+  - pip install flake8
   - python setup.py install
 # command to run tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ cache:
 # command to install dependencies
 install:
   - pip install -r requirements.txt --download-cache $HOME/.pip-cache
+  - pip install flake8 --download-cache $HOME/.pip-cache
   - python setup.py install
 # command to run tests
-script: nosetests
+script:
+  - nosetests
+  - flake8 --exit-zero jiocloud


### PR DESCRIPTION
This adds a non voting flake8 job to travis

Also speeding up the builds by using & caching wheels for pip packages, since most of the time in the CI is spent in building the packages.
 
Builds in less than a minute! yes we can