### PR TITLE
Unittest test_hosts_at_version_none_but_dir_exists

### DIFF
--- a/jiocloud/orchestrate.py
+++ b/jiocloud/orchestrate.py
@@ -140,7 +140,9 @@ class DeploymentOrchestrator(object):
         result_set = set()
         for x in res:
             if x.split('/')[-2] == version:
-                result_set.add(x.split('/')[-1])
+                host = x.split('/')[-1]
+                if host:
+                    result_set.add(host)
         return result_set
 
     def get_failures(self, hosts=False, show_warnings=False):

--- a/jiocloud/tests/test_orchestrate.py
+++ b/jiocloud/tests/test_orchestrate.py
@@ -73,7 +73,7 @@ class OrchestrateTests(unittest.TestCase):
 
     def test_hosts_at_version_none_but_dir_exists(self):
         with mock.patch.object(self.do, '_consul') as consul:
-            consul.return_value.kv.find.return_value = [
+            consul.kv.find.return_value = [
                 '/running_version/foo/'
                 ]
             self.assertEquals(self.do.hosts_at_version('foo'), set([]))


### PR DESCRIPTION
Fixed following issues:
a) consul.return_value doesn't work with mock.patch.object
b) host will be empty string if version_dir end with '/'
like '/running_version/foo/'