### PR TITLE
Support boot from volume

### DIFF
--- a/environment_resources/prod.yaml
+++ b/environment_resources/prod.yaml
@@ -11,3 +11,11 @@ resources:
     image: ubuntu12.04
     networks:
       - ed1755a0-1f0b-47b9-b9ec-6ef5cbb77c61
+
+  baz:
+    number: 3
+    flavor: m1.medium
+    image: ubuntu12.04
+    boot_volume: 50
+    networks:
+      - ed1755a0-1f0b-47b9-b9ec-6ef5cbb77c61

--- a/examples/environment_resources/prod.yaml
+++ b/examples/environment_resources/prod.yaml
@@ -11,3 +11,11 @@ resources:
     image: ubuntu12.04
     networks:
       - ed1755a0-1f0b-47b9-b9ec-6ef5cbb77c61
+
+  baz:             
+    number: 3      
+    flavor: m1.medium
+    image: ubuntu12.04                      
+    boot_volume: 50
+    networks:      
+      - ed1755a0-1f0b-47b9-b9ec-6ef5cbb77c61


### PR DESCRIPTION
This code is to support boot from volume.
Boot from volume takes longer, so to avoid volume status multiple times
(with status BUILD), move printing volume status after it come out of status
BUILD.

This will look for one parameter boot_volume in layout yaml file with value
of volume size in GB.

TODO: Need to learn more to write unittests.