### PR TITLE
Bug fix - Bad loop / retry causing multiple instances.

### DIFF
--- a/jiocloud/apply_resources.py
+++ b/jiocloud/apply_resources.py
@@ -263,11 +263,6 @@ if __name__ == '__main__':
                                                     args.mappings,
                                                     project_tag=args.project_tag,
                                                     number_overrides=number_overrides)
-                break
-            except (requests.ConnectionError, novacexceptions.ClientException) as e:
-                print e
-        while True:
-            try:
                 apply_resources.create_servers(servers, args.userdata,
                                        key_name=args.key_name,
                                        num_retry=args.retry)


### PR DESCRIPTION
Putting servers_to_create and create_servers in separate tries creates a bad loop
when the exception happens in the second loop.
In the case exception is in second loop, it will recreate all the servers it got from
servers_to_create
So, on any exception in either of these, both of them should be run together as a pair
while doing retry