### PR TITLE
Check the port and node exists before try to add

### DIFF
--- a/jiocloud/enroll.py
+++ b/jiocloud/enroll.py
@@ -64,6 +64,17 @@ def p(*args):
     sys.stdout.flush()
 
 def create_node(ironic, username, password, address, mac, total_memory, total_cores):
+    ##
+    # Assuming that if a port exists with a node uuid, the node and chassis exists.
+    # Currently version of ironic we use, dont support easy ways to get details.
+    ##
+
+    port_exist = True if [a.node_uuid for a in ironic.port.list(detail=True) if a.address == mac ] else False
+
+    if port_exist:
+        p('Node and Port already exist')
+        return False
+
     p('Creating chassis.. ',)
     chassis = ironic.chassis.create()
     print(chassis.uuid)


### PR DESCRIPTION
Earlier it was adding the nodes even if it is already exists and raising
exception on port-create, this patch is to check if port exist with certain
node-id and exit without adding any other things.