### PR TITLE
upate lookup regex to work for hosts with num > 9

### DIFF
--- a/jiocloud/orchestrate.py
+++ b/jiocloud/orchestrate.py
@@ -101,7 +101,7 @@ class DeploymentOrchestrator(object):
         return ret_dict
 
     def get_lookup_hash_from_hostname(self, name):
-        m = re.search('(\w+)(\d+)(-.*)?', name)
+        m = re.search('([a-z]+)(\d+)(-.*)?', name)
         if m is None:
             print "Unexpected hostname format %s" % name
             return {}

--- a/jiocloud/tests/test_orchestrate.py
+++ b/jiocloud/tests/test_orchestrate.py
@@ -212,6 +212,9 @@ class OrchestrateTests(unittest.TestCase):
             self.assertEquals(self.do.lookup_ordered_data('config_version', 'host1'), {'key':'v673'})
             consul.return_value.kv.find.assert_called_with('/config_version/host/host1/')
 
+    def test_get_lookup_hash_from_hostname(self):
+        self.assertEqual(self.do.get_lookup_hash_from_hostname('host12'), [['global', ''], ['role', '/host'], ['host', '/host12']])
+
     def test_check_puppet(self):
         with mock.patch('jiocloud.orchestrate.DeploymentOrchestrator.consul', new_callable=mock.PropertyMock) as consul:
             consul.return_value.kv.find.return_value = dict({'enable_puppet':True})


### PR DESCRIPTION
previously, it was just matching the last digit,
this patch updates the regex to match all digits