### PR TITLE
Include more node properties on enrollment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# enroll.py
+  The purpose of this script is to enroll nodes to ironic. This get the details
+from ilo and register the node in ironic.
+
+This will add following properties in ironic.
+
+  number of cpus: Number of cpus in the machine
+  Memory: RAM size
+  Server serial: Server serial number
+  CPU Architecture: This has been determined from the config file, the config
+file contain sections for each server model and have a mapping to right cpu
+architecture and hardware type.
+  Hardware type: Same as above (CPU Architecture)
+
+
+Here is the sample config file.
+```
+$ cat /etc/jiocloud/enroll_nodes.ini
+[ProLiant SL210t Gen8]
+architecture=x86_64.g1.compute
+hw_type=g1.compute
+
+[ProLiant SL210t Gen81]
+yet=another
+architecture=test
+
+[ProLiant SL4540 Gen8]
+architecture=x86_64.g1.storage
+hw_type=g1.storage
+```


### PR DESCRIPTION
This patch will add more node properties on enrollment

* Add node serial number
* Add correct hardware type and cpu_arch
  This is done by getting product name from ilo and match it with the config
file entries. Each product name will have config section in ini config file,
which will have cpu_arch and hardware type configured.
* Added readme.

NOTE: This patch assume that servers of different hardware type/cpu_arch will be
different models, which is true at this moment. May be later we would have to
have more streamlined checks for server properties before decide on the hardware
type.